### PR TITLE
Fix for memory leak

### DIFF
--- a/kivy/uix/screenmanager.py
+++ b/kivy/uix/screenmanager.py
@@ -204,6 +204,7 @@ from kivy.lang import Builder
 from kivy.graphics import (RenderContext, Rectangle, Fbo,
                            ClearColor, ClearBuffers, BindTexture, PushMatrix,
                            PopMatrix, Translate, Callback, Scale)
+import gc
 
 
 class ScreenManagerException(Exception):
@@ -530,6 +531,10 @@ class ShaderTransition(TransitionBase):
         self.manager.canvas.remove(self.render_ctx)
         self._remove_out_canvas()
         self.manager.real_add_widget(self.screen_in)
+        self.fbo_in = None
+        self.fbo_out = None
+        self.render_ctx = None
+        gc.collect()
 
     def stop(self):
         self._remove_out_canvas()


### PR DESCRIPTION
Linux pc
[INFO   ] [Kivy        ] v1.11.1
[INFO   ] [Python      ] v2.7.12
Using shader transtion I get RAM memory leak in GPU. I used radeontop program to see memory leak.

There is a lot of create issues in Kivy repo about screenmanager transitions errors. This  should fix issues on RPI where GPU memory is even smaller.

On platform where memory card uses shared memory leak might be more visible.

Note: gc.collect fixes issue alone but keeps a lot of memory usage, When setting to None a lot of memory is freed. 